### PR TITLE
Fixing multiprocessing python tests on Linux

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run Tests and Build Wheel
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -24,12 +24,21 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+      - name: Configure Ubuntu
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          PROTOC_OS_ARCH=linux-x86_64
+          echo "::set-env name=PROTOC_OS_ARCH::$PROTOC_OS_ARCH"
+      - name: Configure MacOS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          PROTOC_OS_ARCH=osx-x86_64
+          echo "::set-env name=PROTOC_OS_ARCH::$PROTOC_OS_ARCH"
       - name: Install protoc
         run: |
-          PROTOC_VERSION=3.12.3
-          OS_ARCH=osx-x86_64
-          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS_ARCH}.zip"
-          unzip -d "${GITHUB_WORKSPACE}" "protoc-${PROTOC_VERSION}-${OS_ARCH}.zip" bin/protoc
+          PROTOC_VERSION=3.12.4
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_OS_ARCH}.zip"
+          unzip -d "${GITHUB_WORKSPACE}" "protoc-${PROTOC_VERSION}-${PROTOC_OS_ARCH}.zip" bin/protoc
           chmod +x "${GITHUB_WORKSPACE}/bin/protoc"
           ${GITHUB_WORKSPACE}/bin/protoc --version
           export PATH=${GITHUB_WORKSPACE}/bin/:$PATH

--- a/platforms/python/syft/message/syft_message.py
+++ b/platforms/python/syft/message/syft_message.py
@@ -66,7 +66,7 @@ class SyftMessageProxy:
                 if obj is not None:
                     return obj
             except Exception as e:
-                print(f"Python failed to decode response {response_bytes}, error: {e}")
+                print(f"Python failed to decode response, error: {e}")
         return None
 
 


### PR DESCRIPTION
- Changed set_start_method to "spawn" and added daemon=True

## Description
This PR fixes the linux test hanging issue:
https://github.com/OpenMined/syft_experimental/issues/3

## Affected Dependencies
None

## How has this been tested?
Github Actions

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
